### PR TITLE
A few fixes for function and form

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ghcr.io/wiiu-env/devkitppc:20230621
+FROM ghcr.io/wiiu-env/devkitppc:20250608
 
 COPY --from=ghcr.io/wiiu-env/libntfs:20220726 /artifacts $DEVKITPRO
-COPY --from=ghcr.io/wiiu-env/libmocha:20220919 /artifacts $DEVKITPRO
+COPY --from=ghcr.io/wiiu-env/libmocha:20250608 /artifacts $DEVKITPRO
 
 WORKDIR project

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you want to create a partial dump (skipped sectors represented by 00 bytes) f
 When you dump a .wux or .wud to the SD card it gets splitted into 2 GiB parts (FAT32 limitation). To merge them you can use the `copy` cmd tool.
 
 Example:
-`copy /b game.wux.part1 + game.wux.part2 game.wux`
+`copy /b game.wux.part01 + game.wux.part02 game.wux`
 
 ## Dependencies
 Requires an [Environment](https://github.com/wiiu-env/EnvironmentLoader) (e.g. Tiramisu or Aroma) with [MochaPayload](https://github.com/wiiu-env/MochaPayload) (Nightly-MochaPayload-20220725-155554 or newer)

--- a/source/GMPartitionsDumperState.cpp
+++ b/source/GMPartitionsDumperState.cpp
@@ -152,7 +152,7 @@ void GMPartitionsDumperState::render() {
             WiiUScreen::drawLine();
         }
         WiiUScreen::drawLine();
-        WiiUScreen::drawLine("Press B to abort the dumping");
+        WiiUScreen::drawLine("Press X to abort the dumping");
 
     } else if (this->state == STATE_DUMP_DONE) {
         WiiUScreen::drawLine("Dumping done. Press A to return.");
@@ -327,7 +327,7 @@ ApplicationState::eSubState GMPartitionsDumperState::update(Input *input) {
         this->curContentIndex = 0;
         this->state           = STATE_DUMP_PARTITION_CONTENTS;
     } else if (this->state == STATE_DUMP_PARTITION_CONTENTS) {
-        if (buttonPressed(input, Input::BUTTON_B)) {
+        if (buttonPressed(input, Input::BUTTON_X)) {
             this->state = STATE_ABORT_CONFIRMATION;
             return ApplicationState::SUBSTATE_RUNNING;
         }

--- a/source/WUDDumperState.cpp
+++ b/source/WUDDumperState.cpp
@@ -235,6 +235,9 @@ ApplicationState::eSubState WUDDumperState::update(Input *input) {
             this->readResult = 0;
         } else if (buttonPressed(input, Input::BUTTON_Y)) {
             this->autoSkipOnError = true;
+        } else if (buttonPressed(input, Input::BUTTON_X)) {
+            this->state = STATE_ABORT_CONFIRMATION;
+            return ApplicationState::SUBSTATE_RUNNING;
         }
     } else if (this->state == STATE_DUMP_DISC_DONE) {
         WiiUScreen::drawLinef("Dumping done! Press A to continue");

--- a/source/WUDDumperState.cpp
+++ b/source/WUDDumperState.cpp
@@ -145,7 +145,7 @@ ApplicationState::eSubState WUDDumperState::update(Input *input) {
         this->writtenSectors   = 0;
         this->retryCount       = 10;
     } else if (this->state == STATE_DUMP_DISC) {
-        if (buttonPressed(input, Input::BUTTON_B)) {
+        if (buttonPressed(input, Input::BUTTON_X)) {
             this->state = STATE_ABORT_CONFIRMATION;
             return ApplicationState::SUBSTATE_RUNNING;
         }
@@ -287,6 +287,7 @@ void WUDDumperState::render() {
             }
             WiiUScreen::drawLine();
             WiiUScreen::drawLine("Press A to skip this sector (will be replaced by 0's)");
+            WiiUScreen::drawLine("Press Y to activate auto-skip mode");
             WiiUScreen::drawLine("Press B to try again");
         } else {
             OSTime curTime       = OSGetTime();
@@ -305,7 +306,7 @@ void WUDDumperState::render() {
             WiiUScreen::drawLinef("Skipped dumping %d sectors", this->skippedSectors.size());
             WiiUScreen::drawLine();
         }
-        WiiUScreen::drawLinef("Press B to abort");
+        WiiUScreen::drawLinef("Press X to abort");
     } else if (this->state == STATE_DUMP_DISC_DONE) {
         WiiUScreen::drawLinef("Dumping done! Press A to continue");
     } else if (this->state == STATE_ABORT_CONFIRMATION) {

--- a/source/fs/WriteOnlyFileWithCache.cpp
+++ b/source/fs/WriteOnlyFileWithCache.cpp
@@ -22,7 +22,7 @@
 
 #define SPLIT_SIZE (0x80000000)
 
-WriteOnlyFileWithCache::WriteOnlyFileWithCache(const char *path, int32_t cacheSize, bool split) : CFile(split ? std::string(path) + ".part1" : path, WriteOnly),
+WriteOnlyFileWithCache::WriteOnlyFileWithCache(const char *path, int32_t cacheSize, bool split) : CFile(split ? std::string(path) + ".part01" : path, WriteOnly),
                                                                                                   splitFile(split),
                                                                                                   originalPath(path) {
     if (!this->isOpen()) {
@@ -81,8 +81,8 @@ int32_t WriteOnlyFileWithCache::write(const uint8_t *addr, size_t writeSize) {
             CFile::close();
 
             // open the next part
-            DEBUG_FUNCTION_LINE("Open %s", string_format("%s.part%d", originalPath.c_str(), part).c_str());
-            this->open(string_format("%s.part%d", originalPath.c_str(), part), WriteOnly);
+            DEBUG_FUNCTION_LINE("Open %s", string_format("%s.part%02d", originalPath.c_str(), part).c_str());
+            this->open(string_format("%s.part%02d", originalPath.c_str(), part), WriteOnly);
         }
         if (finalWriteSize == 0) {
             return (int32_t) writeSize;
@@ -134,8 +134,8 @@ int32_t WriteOnlyFileWithCache::seek(int64_t offset, int32_t origin) {
                 flush();
                 close();
                 part = (offset / SPLIT_SIZE) + 1;
-                DEBUG_FUNCTION_LINE("Open %s", string_format("%s.part%d", originalPath.c_str(), part).c_str());
-                this->open(string_format("%s.part%d", originalPath.c_str(), part), ReadWrite);
+                DEBUG_FUNCTION_LINE("Open %s", string_format("%s.part%02d", originalPath.c_str(), part).c_str());
+                this->open(string_format("%s.part%02d", originalPath.c_str(), part), ReadWrite);
             }
             return CFile::seek(offset % SPLIT_SIZE, SEEK_SET);
         }


### PR DESCRIPTION
Just a few changes;
- Bumped dockerfile sources to latest (and subsequent versions of following changes were tested with latest without error.)

- Added text to represent the ``"Press Y to auto-skip"`` mode within the program menu so it's more clear that it exists. 

- Designated ``X`` as the global abort button because it is unshared with any other button. Fixes #27 by allowing the ``B`` button to only do a specific task without taking priority over abort functions when trying to retry a sector read. Added support to poll for the ``X`` button during ``STATE_WAIT_USER_ERROR_CONFIRM`` to allow aborting during that menu.

- When writing in chunks to a fat32 SD, part numbers are now padded to two-digits. Fixes #26. ``game.wud.part1``, ``game.wud.part2`` now becomes ``game.wud.part01``, ``game.wud.part02``.
This allows them to be represented in numerical order rather than lexical when wildcard globbing, simplifying concatenation and improving legibility.

All changes tested on hardware without issue.
